### PR TITLE
read data in fixture (example)

### DIFF
--- a/mne/io/edf/tests/test_edf.py
+++ b/mne/io/edf/tests/test_edf.py
@@ -119,17 +119,24 @@ def test_edf_reduced():
                      verbose='error')
 
 
+@pytest.fixture()
+def my_already_loaded_raw(scope='session'):
+    return read_raw_edf(edf_path, stim_channel='auto', preload=True)
+
+
+def test_orig_units(my_already_loaded_raw):
+    """Test exposure of original channel units."""
+    orig_units = my_already_loaded_raw._orig_units
+    assert len(orig_units) == 140
+    assert orig_units['A1'] == u'µV'  # formerly 'uV' edit by _check_orig_units
+
+
 def test_edf_data():
     """Test edf files."""
     raw = _test_raw_reader(read_raw_edf, input_fname=edf_path,
                            stim_channel=None, exclude=['Ergo-Left', 'H10'],
                            verbose='error')
     raw_py = read_raw_edf(edf_path, stim_channel='auto', preload=True)
-
-    # Test original units
-    orig_units = raw_py._orig_units
-    assert len(orig_units) == 140
-    assert orig_units['A1'] == u'µV'  # formerly 'uV' edit by _check_orig_units
 
     assert_equal(len(raw.ch_names) + 2, len(raw_py.ch_names))
     # Test saving and loading when annotations were parsed.


### PR DESCRIPTION
running `pytest mne/io/ -k orig_units` to compare edf and brainvision, you can see that the load in brainvsion is in the call, while in edf is in the setup. 

```sh
~/code/mne-python fixtures* ⇣
(mne) ❯ pytest mne/io/ -k orig_units    
Test session starts (platform: linux, Python 3.6.6, pytest 3.6.3, pytest-sugar 0.9.1)
rootdir: /home/sik/code/mne-python, inifile: setup.cfg
plugins: smother-0.2, sugar-0.9.1, pudb-0.6, ipdb-0.1, faulthandler-1.5.0, cov-2.5.1

 mne/io/brainvision/tests/test_brainvision.py ✓                                                  25% ██▌       
 mne/io/edf/tests/test_edf.py ✓                                                                  50% █████     
 mne/io/tests/test_base.py ✓                                                                     75% ███████▌  
 mne/io/tests/test_utils.py ✓                                                                   100% ██████████
========================================== slowest 20 test durations ==========================================
0.01s setup    mne/io/edf/tests/test_edf.py::test_orig_units
0.01s call     mne/io/brainvision/tests/test_brainvision.py::test_orig_units
0.00s call     mne/io/tests/test_base.py::test_orig_units
0.00s call     mne/io/tests/test_utils.py::test_check_orig_units
0.00s teardown mne/io/brainvision/tests/test_brainvision.py::test_orig_units
0.00s setup    mne/io/brainvision/tests/test_brainvision.py::test_orig_units
0.00s teardown mne/io/edf/tests/test_edf.py::test_orig_units
0.00s teardown mne/io/tests/test_base.py::test_orig_units
0.00s setup    mne/io/tests/test_utils.py::test_check_orig_units
0.00s call     mne/io/edf/tests/test_edf.py::test_orig_units
0.00s teardown mne/io/tests/test_utils.py::test_check_orig_units
0.00s setup    mne/io/tests/test_base.py::test_orig_units

Results (0.50s):
       4 passed
     208 deselected
```

In this manner, then the already loaded raw can be used in many places paying the loading price only once. 

`pytest mne/io/ -k orig_units --setup-show` shows when the features are executed. And the parameter `scope` allows controlling if you want the code of the fixture being run every time is called or just one per `module`, `session` or `class`

